### PR TITLE
Add Core Data model with QuestionEntity definition

### DIFF
--- a/NindoCode/App/Persistence/CoreDataModel.xcdatamodeld/CoreDataModel.xcdatamodel/contents
+++ b/NindoCode/App/Persistence/CoreDataModel.xcdatamodeld/CoreDataModel.xcdatamodel/contents
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24411" systemVersion="25B78" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+    <entity name="QuestionEntity" representedClassName=".QuestionEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="correctIndex" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="optionsData" optional="YES" attributeType="Binary"/>
+        <attribute name="text" optional="YES" attributeType="String"/>
+    </entity>
+</model>


### PR DESCRIPTION
This PR adds the initial Core Data model to the project. It includes the creation of the QuestionEntity with the attributes needed for the quiz feature: id, text, optionsData and correctIndex. This prepares the foundation for saving and loading quiz questions in a persistent storage layer.