### PR TITLE
Add questions.json with initial quiz data

### DIFF
--- a/NindoCode/App/Persistence/CoreDataModel.xcdatamodeld/CoreDataModel.xcdatamodel/contents
+++ b/NindoCode/App/Persistence/CoreDataModel.xcdatamodeld/CoreDataModel.xcdatamodel/contents
@@ -6,4 +6,7 @@
         <attribute name="optionsData" optional="YES" attributeType="Binary"/>
         <attribute name="text" optional="YES" attributeType="String"/>
     </entity>
+    <entity name="VersionEntity" representedClassName="VersionEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="version" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
 </model>

--- a/NindoCode/App/Persistence/Persistence.swift
+++ b/NindoCode/App/Persistence/Persistence.swift
@@ -1,10 +1,3 @@
-//
-//  Persistence.swift
-//  NindoCode
-//
-//  Created by Jefferson Batista on 26/11/25.
-//
-
 import CoreData
 
 struct PersistenceController {

--- a/NindoCode/Resources/questions.json
+++ b/NindoCode/Resources/questions.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "questions": [
+    {
+      "text": "Qual é a função de entrada padrão em Kotlin?",
+      "options": ["start()", "main()", "run()", "init()"],
+      "correctIndex": 1
+    },
+    {
+      "text": "Qual operador elvis em Kotlin?",
+      "options": ["?:", "??", "?.", "!!"],
+      "correctIndex": 0
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds the questions.json file to the project. It introduces a simple bundle based structure for storing quiz content, including version control and the initial set of questions. This JSON file will be used as the main source of truth for importing quiz data into Core Data.