### PR TITLE
Add subject and topic fields to Question model and Core Data structure

### DIFF
--- a/NindoCode/App/Persistence/CoreDataModel.xcdatamodeld/CoreDataModel.xcdatamodel/contents
+++ b/NindoCode/App/Persistence/CoreDataModel.xcdatamodeld/CoreDataModel.xcdatamodel/contents
@@ -4,7 +4,9 @@
         <attribute name="correctIndex" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="optionsData" optional="YES" attributeType="Binary"/>
+        <attribute name="subject" optional="YES" attributeType="String"/>
         <attribute name="text" optional="YES" attributeType="String"/>
+        <attribute name="topic" optional="YES" attributeType="String"/>
     </entity>
     <entity name="VersionEntity" representedClassName="VersionEntity" syncable="YES" codeGenerationType="class">
         <attribute name="version" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>

--- a/NindoCode/App/Persistence/QuestionEntity+Helpers.swift
+++ b/NindoCode/App/Persistence/QuestionEntity+Helpers.swift
@@ -2,13 +2,10 @@ import CoreData
 
 extension QuestionEntity {
 
-    var safeId: UUID {
-        id ?? UUID()
-    }
-
-    var safeText: String {
-        text ?? ""
-    }
+    var safeId: UUID { id ?? UUID() }
+    var safeText: String { text ?? "" }
+    var safeSubject: String { subject ?? "" }
+    var safeTopic: String { topic ?? "" }
 
     var options: [String] {
         guard let data = optionsData else { return [] }

--- a/NindoCode/App/Persistence/QuestionsFile.swift
+++ b/NindoCode/App/Persistence/QuestionsFile.swift
@@ -6,6 +6,8 @@ struct QuestionsFile: Codable {
 }
 
 struct QuestionDTO: Codable {
+    let subject: String
+    let topic: String
     let text: String
     let options: [String]
     let correctIndex: Int

--- a/NindoCode/App/Persistence/QuestionsImporter.swift
+++ b/NindoCode/App/Persistence/QuestionsImporter.swift
@@ -51,6 +51,8 @@ enum QuestionsImporter {
             entity.text = item.text
             entity.correctIndex = Int16(item.correctIndex)
             entity.optionsData = try? JSONEncoder().encode(item.options)
+            entity.subject = item.subject
+            entity.topic = item.topic
         }
 
         try? context.save()

--- a/NindoCode/Features/Quiz/Domain/Question.swift
+++ b/NindoCode/Features/Quiz/Domain/Question.swift
@@ -5,4 +5,6 @@ struct Question: Identifiable, Equatable {
     let text: String
     let options: [String]
     let correctIndex: Int
+    let subject: String
+    let topic: String
 }

--- a/NindoCode/Features/Quiz/QuestionRepository.swift
+++ b/NindoCode/Features/Quiz/QuestionRepository.swift
@@ -22,7 +22,9 @@ final class QuestionRepository: QuestionRepositoryProtocol {
                 id: entity.safeId,
                 text: entity.safeText,
                 options: entity.options,
-                correctIndex: Int(entity.correctIndex)
+                correctIndex: Int(entity.correctIndex),
+                subject: entity.safeSubject,
+                topic: entity.safeTopic
             )
         }
     }

--- a/NindoCode/Resources/questions.json
+++ b/NindoCode/Resources/questions.json
@@ -1,15 +1,19 @@
 {
-  "version": 1,
+  "version": 2,
   "questions": [
     {
-      "text": "Qual é a função de entrada padrão em Kotlin?",
-      "options": ["start()", "main()", "run()", "init()"],
-      "correctIndex": 1
+      "subject": "Swift",
+      "topic": "Arrays",
+      "text": "How do you create an empty Array of Int in Swift?",
+      "options": ["[]", "[Int]()", "Array<Int>()", "int[]"],
+      "correctIndex": 2
     },
     {
-      "text": "Qual operador elvis em Kotlin?",
-      "options": ["?:", "??", "?.", "!!"],
-      "correctIndex": 0
+      "subject": "Kotlin",
+      "topic": "Lifecycle",
+      "text": "Which method is called when an Activity becomes visible?",
+      "options": ["onCreate", "onStart", "onResume", "onPause"],
+      "correctIndex": 1
     }
   ]
 }


### PR DESCRIPTION
This PR introduces the initial data layer changes required for filtering quiz questions by subject and topic.

Updates include:
• Adding subject and topic fields to the Question domain model  
• Updating QuestionDTO to decode these new fields from questions.json  
• Extending QuestionEntity with subject and topic attributes in Core Data  
• Updating the QuestionsImporter to save the new fields during import  
• Adjusting QuestionRepository to convert subject and topic into the domain model  

These changes prepare the foundation for the upcoming feature that will allow users to select a subject and topic before starting the quiz.