### PR TITLE
Add subject attribute to VersionEntity for per subject version tracking

### DIFF
--- a/NindoCode/App/Persistence/CoreDataModel.xcdatamodeld/CoreDataModel.xcdatamodel/contents
+++ b/NindoCode/App/Persistence/CoreDataModel.xcdatamodeld/CoreDataModel.xcdatamodel/contents
@@ -9,6 +9,7 @@
         <attribute name="topic" optional="YES" attributeType="String"/>
     </entity>
     <entity name="VersionEntity" representedClassName="VersionEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="subject" optional="YES" attributeType="String"/>
         <attribute name="version" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
     </entity>
 </model>

--- a/NindoCode/App/Persistence/QuestionsFile.swift
+++ b/NindoCode/App/Persistence/QuestionsFile.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 struct QuestionsFile: Codable {
+    let subject: String
     let version: Int
     let questions: [QuestionDTO]
 }
 
 struct QuestionDTO: Codable {
-    let subject: String
     let topic: String
     let text: String
     let options: [String]

--- a/NindoCode/App/Persistence/QuestionsImporter.swift
+++ b/NindoCode/App/Persistence/QuestionsImporter.swift
@@ -4,43 +4,114 @@ import CoreData
 enum QuestionsImporter {
 
     static func updateQuestionsIfNeeded(context: NSManagedObjectContext) {
-        guard let url = Bundle.main.url(forResource: "questions", withExtension: "json"),
-              let data = try? Data(contentsOf: url) else {
+        let fileNames = loadQuestionFileNames()
+
+        for fileName in fileNames {
+            importIfNeeded(
+                fileName: fileName,
+                context: context
+            )
+        }
+    }
+
+    // MARK: - Private
+
+    private static func loadQuestionFileNames() -> [String] {
+        guard let urls = Bundle.main.urls(
+            forResourcesWithExtension: "json",
+            subdirectory: "Questions"
+        ) else {
+            return []
+        }
+
+        return urls.map {
+            $0.deletingPathExtension().lastPathComponent
+        }
+    }
+
+    private static func importIfNeeded(
+        fileName: String,
+        context: NSManagedObjectContext
+    ) {
+        guard let url = Bundle.main.url(
+            forResource: fileName,
+            withExtension: "json",
+            subdirectory: "Questions"
+        ),
+        let data = try? Data(contentsOf: url)
+        else {
             return
         }
 
         let decoder = JSONDecoder()
+
         guard let file = try? decoder.decode(QuestionsFile.self, from: data) else {
             return
         }
 
-        let localVersion = getLocalVersion(context: context)
+        let localVersion = getLocalVersion(
+            subject: file.subject,
+            context: context
+        )
 
-        if file.version > localVersion {
-            importQuestions(file.questions, context: context)
-            setLocalVersion(context: context, version: file.version)
+        guard file.version > localVersion else {
+            return
         }
+
+        importQuestions(
+            file.questions,
+            subject: file.subject,
+            context: context
+        )
+
+        setLocalVersion(
+            subject: file.subject,
+            version: file.version,
+            context: context
+        )
     }
 
-    private static func getLocalVersion(context: NSManagedObjectContext) -> Int {
+    private static func getLocalVersion(
+        subject: String,
+        context: NSManagedObjectContext
+    ) -> Int {
         let fetch: NSFetchRequest<VersionEntity> = VersionEntity.fetchRequest()
+        fetch.predicate = NSPredicate(format: "subject == %@", subject)
         fetch.fetchLimit = 1
 
         if let current = try? context.fetch(fetch).first {
             return Int(current.version)
         }
+
         return 0
     }
 
-    private static func setLocalVersion(context: NSManagedObjectContext, version: Int) {
+    private static func setLocalVersion(
+        subject: String,
+        version: Int,
+        context: NSManagedObjectContext
+    ) {
         let fetch: NSFetchRequest<VersionEntity> = VersionEntity.fetchRequest()
-        let current = (try? context.fetch(fetch).first) ?? VersionEntity(context: context)
-        current.version = Int32(version)
+        fetch.predicate = NSPredicate(format: "subject == %@", subject)
+        fetch.fetchLimit = 1
+
+        let entity = (try? context.fetch(fetch).first)
+            ?? VersionEntity(context: context)
+
+        entity.subject = subject
+        entity.version = Int32(version)
+
         try? context.save()
     }
 
-    private static func importQuestions(_ list: [QuestionDTO], context: NSManagedObjectContext) {
+    private static func importQuestions(
+        _ list: [QuestionDTO],
+        subject: String,
+        context: NSManagedObjectContext
+    ) {
         let fetch: NSFetchRequest<QuestionEntity> = QuestionEntity.fetchRequest()
+        fetch.predicate = NSPredicate(format: "subject == %@", subject)
+
         if let old = try? context.fetch(fetch) {
             old.forEach { context.delete($0) }
         }
@@ -51,7 +122,7 @@ enum QuestionsImporter {
             entity.text = item.text
             entity.correctIndex = Int16(item.correctIndex)
             entity.optionsData = try? JSONEncoder().encode(item.options)
-            entity.subject = item.subject
+            entity.subject = subject
             entity.topic = item.topic
         }
 

--- a/NindoCode/Resources/Questions/kotlin.json
+++ b/NindoCode/Resources/Questions/kotlin.json
@@ -1,0 +1,12 @@
+{
+  "subject": "Kotlin",
+  "version": 1,
+  "questions": [
+    {
+      "topic": "Lifecycle",
+      "text": "Which method is called when an Activity becomes visible?",
+      "options": ["onCreate", "onStart", "onResume", "onPause"],
+      "correctIndex": 1
+    }
+  ]
+}

--- a/NindoCode/Resources/Questions/swift.json
+++ b/NindoCode/Resources/Questions/swift.json
@@ -1,0 +1,19 @@
+
+{
+  "subject": "Swift",
+  "version": 1,
+  "questions": [
+    {
+      "topic": "Arrays",
+      "text": "How do you create an empty array of Int in Swift?",
+      "options": ["[]", "[Int]()", "Array<Int>()", "int[]"],
+      "correctIndex": 2
+    },
+    {
+      "topic": "Optionals",
+      "text": "What does the ? symbol represent in Swift?",
+      "options": ["Nullable", "Optional", "Pointer", "Reference"],
+      "correctIndex": 1
+    }
+  ]
+}


### PR DESCRIPTION
This PR updates the Core Data model by adding a subject attribute to VersionEntity.

This change enables independent version tracking for each question subject,
allowing the QuestionsImporter to safely manage multiple JSON files split by subject.

With this update:
• Each subject maintains its own version number
• Import logic no longer relies on a global version
• Subject based question updates are fully supported

This fixes the build error caused by the missing VersionEntity.subject property
and completes the multi subject import pipeline.