### PR TITLE
Add SelectTopicView UI with preview mock support

### DIFF
--- a/NindoCode/Features/Quiz/QuestionRepository.swift
+++ b/NindoCode/Features/Quiz/QuestionRepository.swift
@@ -4,6 +4,12 @@ protocol QuestionRepositoryProtocol {
     func fetchQuestions(filter: QuizFilter?) throws -> [Question]
 }
 
+final class PreviewQuestionRepository: QuestionRepositoryProtocol {
+    func fetchQuestions(filter: QuizFilter?) throws -> [Question] {
+        []
+    }
+}
+
 final class QuestionRepository: QuestionRepositoryProtocol {
 
     private let context: NSManagedObjectContext

--- a/NindoCode/Features/Setup/SetupViewModel.swift
+++ b/NindoCode/Features/Setup/SetupViewModel.swift
@@ -73,3 +73,21 @@ final class SetupViewModel: ObservableObject {
         selectedTopic = nil
     }
 }
+
+extension SetupViewModel {
+
+    static func previewMock(
+        subjects: [String],
+        topicsBySubject: [String: [String]],
+        selectedSubject: String
+    ) -> SetupViewModel {
+
+        let dummyRepo = PreviewQuestionRepository()
+
+        let vm = SetupViewModel(repository: dummyRepo)
+        vm.selectedSubject = selectedSubject
+        vm.subjects = subjects
+        vm.topicsBySubject = topicsBySubject
+        return vm
+    }
+}

--- a/NindoCode/Features/Setup/Views/SelectTopicView.swift
+++ b/NindoCode/Features/Setup/Views/SelectTopicView.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+import CoreData
+
+struct SelectTopicView: View {
+
+    @ObservedObject var viewModel: SetupViewModel
+    let onTopicSelected: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: 24) {
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Choose a topic")
+                        .font(.largeTitle)
+                        .bold()
+
+                    if let subject = viewModel.selectedSubject {
+                        Text(subject)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                VStack(spacing: 0) {
+                    ForEach(viewModel.topicsForSelectedSubject, id: \.self) { topic in
+                        Button {
+                            viewModel.selectedTopic = topic
+                            onTopicSelected()
+                        } label: {
+                            HStack {
+                                Text(topic)
+                                    .font(.headline)
+                                    .foregroundStyle(.blue)
+
+                                Spacer()
+
+                                Image(systemName: "chevron.right")
+                                    .foregroundStyle(.secondary)
+                            }
+                            .padding()
+                        }
+
+                        if topic != viewModel.topicsForSelectedSubject.last {
+                            Divider()
+                        }
+                    }
+                }
+                .background(
+                    RoundedRectangle(cornerRadius: 16)
+                        .fill(Color(.systemBackground))
+                )
+
+                Spacer()
+            }
+            .padding()
+        }
+    }
+}
+
+#Preview {
+    let viewModel = SetupViewModel.previewMock(
+        subjects: ["Swift"],
+        topicsBySubject: [
+            "Swift": [
+                "Arrays",
+                "Optionals",
+                "Closures",
+                "Protocols",
+                "Concurrency"
+            ]
+        ],
+        selectedSubject: "Swift"
+    )
+
+    SelectTopicView(
+        viewModel: viewModel,
+        onTopicSelected: {}
+    )
+}

--- a/NindoCodeUITests/NindoCodeUITestsLaunchTests.swift
+++ b/NindoCodeUITests/NindoCodeUITestsLaunchTests.swift
@@ -9,7 +9,7 @@ import XCTest
 
 final class NindoCodeUITestsLaunchTests: XCTestCase {
 
-    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+    override static var runsForEachTargetApplicationUIConfiguration: Bool {
         true
     }
 


### PR DESCRIPTION
This PR introduces the SelectTopicView UI as the next step in the Setup flow.

Changes included:
• Added SelectTopicView for topic selection UI
• Kept SelectTopicView inside the Setup feature (wizard-style flow)
• Added preview mock support for SetupViewModel without breaking encapsulation
• Ensured Preview does not depend on CoreData or real repositories

This prepares the Setup flow for subject → topic → quiz navigation,
while keeping responsibilities clear and scalable.