### PR TITLE
Add topic selection step to Setup flow

### DIFF
--- a/NindoCode/Features/Setup/SetupCoordinator.swift
+++ b/NindoCode/Features/Setup/SetupCoordinator.swift
@@ -1,6 +1,13 @@
 import SwiftUI
 
 final class SetupCoordinator {
+    
+    enum Step {
+        case subject
+        case topic
+    }
+
+    @State private var step: Step = .subject
 
     private let repository: QuestionRepositoryProtocol
     private let onFinish: (QuizFilter) -> Void
@@ -17,12 +24,25 @@ final class SetupCoordinator {
     func start() -> some View {
         let viewModel = SetupViewModel(repository: repository)
 
-        SelectSubjectView(
-            viewModel: viewModel,
-            onSubjectSelected: {
-                let filter = viewModel.makeQuizFilter()
-                self.onFinish(filter)
-            }
-        )
+        switch step {
+        case .subject:
+            SelectSubjectView(
+                viewModel: viewModel,
+                onSubjectSelected: {
+                    self.step = .topic
+                }
+            )
+
+        case .topic:
+            SelectTopicView(
+                viewModel: viewModel,
+                onTopicSelected: {
+                },
+                onBack: {
+                    viewModel.resetSelection()
+                    self.step = .subject
+                }
+            )
+        }
     }
 }

--- a/NindoCode/Features/Setup/Views/SelectTopicView.swift
+++ b/NindoCode/Features/Setup/Views/SelectTopicView.swift
@@ -5,10 +5,22 @@ struct SelectTopicView: View {
 
     @ObservedObject var viewModel: SetupViewModel
     let onTopicSelected: () -> Void
+    let onBack: () -> Void
 
     var body: some View {
         NavigationStack {
             VStack(alignment: .leading, spacing: 24) {
+
+                HStack {
+                    Button {
+                        onBack()
+                    } label: {
+                        Image(systemName: "chevron.left")
+                            .font(.headline)
+                    }
+
+                    Spacer()
+                }
 
                 VStack(alignment: .leading, spacing: 8) {
                     Text("Choose a topic")
@@ -32,9 +44,7 @@ struct SelectTopicView: View {
                                 Text(topic)
                                     .font(.headline)
                                     .foregroundStyle(.blue)
-
                                 Spacer()
-
                                 Image(systemName: "chevron.right")
                                     .foregroundStyle(.secondary)
                             }
@@ -75,6 +85,6 @@ struct SelectTopicView: View {
 
     SelectTopicView(
         viewModel: viewModel,
-        onTopicSelected: {}
+        onTopicSelected: {}, onBack: {}
     )
 }


### PR DESCRIPTION
This PR extends the Setup flow to include a topic selection step after
subject selection.

Changes included:
• Added internal step navigation to SetupCoordinator (subject → topic)
• Integrated SelectTopicView into the Setup flow
• Added back navigation from topic selection to subject selection
• Kept all logic within the Setup feature, preserving the wizard-style flow
• Deferred quiz navigation until both subject and topic are selected

This prepares the Setup flow for full subject → topic → quiz navigation
without introducing additional coordinators or unnecessary complexity.