### PR TITLE
Add quiz options screen structure to setup flow

### DIFF
--- a/NindoCode/Features/Setup/Domain/QuizFilter.swift
+++ b/NindoCode/Features/Setup/Domain/QuizFilter.swift
@@ -3,4 +3,5 @@ import Foundation
 struct QuizFilter: Equatable {
     let subject: String?
     let topic: String?
+    let numberOfQuestions: Int?
 }

--- a/NindoCode/Features/Setup/SetupViewModel.swift
+++ b/NindoCode/Features/Setup/SetupViewModel.swift
@@ -8,6 +8,7 @@ final class SetupViewModel: ObservableObject {
 
     @Published var selectedSubject: String?
     @Published var selectedTopic: String?
+    @Published var numberOfQuestions: Int = 10
 
     @Published private(set) var subjects: [String] = []
     @Published private(set) var topicsBySubject: [String: [String]] = [:]
@@ -62,7 +63,8 @@ final class SetupViewModel: ObservableObject {
     func makeQuizFilter() -> QuizFilter {
         QuizFilter(
             subject: selectedSubject,
-            topic: selectedTopic
+            topic: selectedTopic,
+            numberOfQuestions: numberOfQuestions
         )
     }
 

--- a/NindoCode/Features/Setup/Views/QuizOptionsView.swift
+++ b/NindoCode/Features/Setup/Views/QuizOptionsView.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+struct QuizOptionsView: View {
+
+    @ObservedObject var viewModel: SetupViewModel
+
+    let onStartQuiz: () -> Void
+    let onBack: () -> Void
+
+    private let questionOptions = [5, 10, 15, 20]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 32) {
+
+            // Header
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Quiz setup")
+                    .font(.largeTitle)
+                    .bold()
+
+                if let subject = viewModel.selectedSubject {
+                    Text(subject)
+                        .font(.headline)
+                        .foregroundStyle(.secondary)
+                }
+
+                if let topic = viewModel.selectedTopic {
+                    Text(topic)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            // Number of questions
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Número de perguntas")
+                    .font(.headline)
+
+                HStack(spacing: 12) {
+                    ForEach(questionOptions, id: \.self) { count in
+                        Button {
+                            viewModel.numberOfQuestions = count
+                        } label: {
+                            Text("\(count)")
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 12)
+                                .background(
+                                    viewModel.numberOfQuestions == count
+                                    ? Color.accentColor.opacity(0.2)
+                                    : Color.gray.opacity(0.1)
+                                )
+                                .clipShape(RoundedRectangle(cornerRadius: 12))
+                        }
+                    }
+                }
+            }
+
+            Spacer()
+
+            // Actions
+            HStack {
+                Button("Voltar") {
+                    onBack()
+                }
+                .buttonStyle(.bordered)
+
+                Spacer()
+
+                Button("Iniciar quiz") {
+                    onStartQuiz()
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(viewModel.numberOfQuestions <= 0)
+            }
+        }
+        .padding()
+        .navigationBarHidden(true)
+    }
+}


### PR DESCRIPTION
This PR introduces the initial UI structure for configuring quiz options during setup.

What was added:
	•	New QuizOptionsView under Features/Setup/Views
	•	UI to display selected subject and topic
	•	Selector for number of questions
	•	Forward and back actions exposed via closures
	•	Minor extension to SetupViewModel to support question count

What was intentionally not included:
	•	Navigation integration
	•	Coordinator flow changes
	•	Quiz logic updates

This keeps the change focused and prepares the setup flow for the next iteration.