### PR TITLE
Add setup flow navigation to question count selection

### DIFF
--- a/NindoCode/Features/Setup/SetupCoordinator.swift
+++ b/NindoCode/Features/Setup/SetupCoordinator.swift
@@ -7,12 +7,13 @@ final class SetupCoordinator: ObservableObject {
     enum Step {
         case subject
         case topic
+        case options
     }
 
     @Published var step: Step = .subject
 
-    let repository: QuestionRepositoryProtocol
-    let onFinish: (QuizFilter) -> Void
+    private let repository: QuestionRepositoryProtocol
+    private let onFinish: (QuizFilter) -> Void
 
     init(
         repository: QuestionRepositoryProtocol,
@@ -22,11 +23,37 @@ final class SetupCoordinator: ObservableObject {
         self.onFinish = onFinish
     }
 
-    func goToTopic() {
+    @ViewBuilder
+    func start() -> some View {
+        SetupFlowView(coordinator: self)
+    }
+
+    // MARK: - Navigation actions
+
+    func goToTopics() {
         step = .topic
     }
 
-    func goBackToSubject() {
+    func goToOptions() {
+        step = .options
+    }
+
+    func goBackToSubject(viewModel: SetupViewModel) {
+        viewModel.resetSelection()
         step = .subject
+    }
+
+    func goBackToTopic(viewModel: SetupViewModel) {
+        viewModel.selectedTopic = nil
+        step = .topic
+    }
+
+    func finishSetup(with filter: QuizFilter) {
+        onFinish(filter)
+    }
+
+    // Expose repository internally
+    var quizRepository: QuestionRepositoryProtocol {
+        repository
     }
 }

--- a/NindoCode/Features/Setup/SetupFlowView.swift
+++ b/NindoCode/Features/Setup/SetupFlowView.swift
@@ -9,7 +9,7 @@ struct SetupFlowView: View {
         self.coordinator = coordinator
         _viewModel = StateObject(
             wrappedValue: SetupViewModel(
-                repository: coordinator.repository
+                repository: coordinator.quizRepository
             )
         )
     }
@@ -21,7 +21,7 @@ struct SetupFlowView: View {
             SelectSubjectView(
                 viewModel: viewModel,
                 onSubjectSelected: {
-                    coordinator.goToTopic()
+                    coordinator.goToTopics()
                 }
             )
 
@@ -29,12 +29,22 @@ struct SetupFlowView: View {
             SelectTopicView(
                 viewModel: viewModel,
                 onTopicSelected: {
-                    let filter = viewModel.makeQuizFilter()
-                    coordinator.onFinish(filter)
+                    coordinator.goToOptions()
                 },
                 onBack: {
-                    viewModel.resetSelection()
-                    coordinator.goBackToSubject()
+                    coordinator.goBackToSubject(viewModel: viewModel)
+                }
+            )
+
+        case .options:
+            QuizOptionsView(
+                viewModel: viewModel,
+                onStartQuiz: {
+                    let filter = viewModel.makeQuizFilter()
+                    coordinator.finishSetup(with: filter)
+                },
+                onBack: {
+                    coordinator.goBackToTopic(viewModel: viewModel)
                 }
             )
         }


### PR DESCRIPTION
This PR extends the setup flow by adding a new options step after topic selection.

Changes included:
	•	Added .options step to SetupCoordinator
	•	Centralized setup navigation logic in SetupFlowView
	•	Wired SelectTopicView to navigate forward to QuizOptionsView
	•	Added backward navigation handling to preserve and reset state correctly
	•	No quiz logic changes yet, setup flow only

This keeps responsibilities well separated:
	•	Coordinator handles flow state
	•	FlowView renders the correct screen
	•	ViewModel holds setup data